### PR TITLE
Regex

### DIFF
--- a/melusine/prepare_email/build_historic.py
+++ b/melusine/prepare_email/build_historic.py
@@ -86,12 +86,14 @@ def __filter_overlap(index):
 
     return index_f[:i+1]
 
+
 def is_only_typo(text):
    """check if the string contains any word character"""
    if not re.search(r"\w", text):
        return True
    else:
        return False
+       
 
 def __remove_empty_mails(structured_historic):
     """If an interval between two matches of transitions is empty (or typographic)

--- a/melusine/utils/printer.py
+++ b/melusine/utils/printer.py
@@ -24,9 +24,10 @@ def print_color_mail(structured_body):
             tag = sentence.get("tags")
             print_color(text, tag)
 
-
+       
 def print_color(text, part=None):
     """Select according to the tag the right color to use when printing."""
+    text = text.replace("\r", "")
     switcher_tag = {
         "HELLO": "\033[0;37;44m" + "HELLO" + "\033[0m",
         "GREETINGS": "\033[0;37;45m" + "GREETINGS" + "\033[0m",
@@ -53,8 +54,7 @@ def print_color(text, part=None):
         "HEADER": "\033[0;37;41m" + text + "\033[0m"
     }
 
-    # print("TAG : ", switcher_tag.get(part, text))
-    if part == "BODY":
-        print("> BODY : ", switcher.get(part, text))
+    if part in switcher.keys():
+       print("> ", switcher_tag.get(part, text), " : ", switcher.get(part, text), "\n")
     else:
-        print("> ", switcher_tag.get(part, text), " : ", switcher.get(part, text))
+       print("> BODY : ", switcher.get(part, text), "\n")

--- a/tests/unit_tests/prepare_email/test_build_historic.py
+++ b/tests/unit_tests/prepare_email/test_build_historic.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from melusine.prepare_email.build_historic import build_historic
 
-body = " \n  \n  \n Bonjours, \n  \n Suite a notre conversation téléphonique \
+body = "En date de lun. 10 mai 2018 LeSociétaire a écrit\nObjet : Demande de régularisation \n  \n  \n Bonjours, \n  \n Suite a notre conversation téléphonique \
 de Mardi , pourriez vous me dire la \n somme que je vous dois afin d'd'être \
 en régularisation . \n  \n Merci bonne journée \n  \n Le mar. 22 mai 2018 \
 à 10:20,  <gestionsocietaire@mutuelle.fr> a écrit\xa0: \n\nObjet : Envoi d'un document \n\n Bonjour. \n  \n \
@@ -12,10 +12,10 @@ nécessite Adobe Reader. \n  "
 
 
 output = [
-    {'text': " \n  \n  \n Bonjours, \n  \n Suite a notre conversation \
+    {'text': "Bonjours, \n  \n Suite a notre conversation \
 téléphonique de Mardi , pourriez vous me dire la \n somme que je vous \
 dois afin d'd'être en régularisation . \n  \n Merci bonne journée",
-     'meta': ''},
+     'meta': 'En date de lun. 10 mai 2018 LeSociétaire a écrit\nObjet : Demande de régularisation \n  \n  \n '},
     {'text': "Bonjour. \n  \n Merci de bien vouloir prendre connaissance \
 du document ci-joint : \n 1 - Relevé d'identité postal MUTUELLE \
 (contrats) \n  \n Sentiments mutualistes. \n  \n La Mututelle \n  \n \

--- a/tests/unit_tests/prepare_email/test_build_historic.py
+++ b/tests/unit_tests/prepare_email/test_build_historic.py
@@ -4,7 +4,7 @@ from melusine.prepare_email.build_historic import build_historic
 body = " \n  \n  \n Bonjours, \n  \n Suite a notre conversation téléphonique \
 de Mardi , pourriez vous me dire la \n somme que je vous dois afin d'd'être \
 en régularisation . \n  \n Merci bonne journée \n  \n Le mar. 22 mai 2018 \
-à 10:20,  <gestionsocietaire@mutuelle.fr> a écrit\xa0: \n Bonjour. \n  \n \
+à 10:20,  <gestionsocietaire@mutuelle.fr> a écrit\xa0: \n\nObjet : Envoi d'un document \n\n Bonjour. \n  \n \
 Merci de bien vouloir prendre connaissance du document ci-joint : \n 1 - \
 Relevé d'identité postal MUTUELLE (contrats) \n  \n Sentiments \
 mutualistes. \n  \n La Mututelle \n  \n La visualisation des fichiers PDF \
@@ -16,12 +16,13 @@ output = [
 téléphonique de Mardi , pourriez vous me dire la \n somme que je vous \
 dois afin d'd'être en régularisation . \n  \n Merci bonne journée",
      'meta': ''},
-    {'text': " \n Bonjour. \n  \n Merci de bien vouloir prendre connaissance \
+    {'text': "Bonjour. \n  \n Merci de bien vouloir prendre connaissance \
 du document ci-joint : \n 1 - Relevé d'identité postal MUTUELLE \
 (contrats) \n  \n Sentiments mutualistes. \n  \n La Mututelle \n  \n \
 La visualisation des fichiers PDF nécessite Adobe Reader. \n  ",
-     'meta': ' \n  \n Le mar. 22 mai 2018 à 10:20,  \
-<gestionsocietaire@mutuelle.fr> a écrit\xa0:'}]
+     'meta': " \n  \n Le mar. 22 mai 2018 à 10:20,  \
+<gestionsocietaire@mutuelle.fr> a écrit\xa0: \n\nObjet : Envoi d'un document \n\n "}]
+
 
 
 def test_build_historic():


### PR DESCRIPTION
Improvement of build_historic. 

Before that, if multiples patterns of transition were contiguous then the interval between the patterns (even if it is empty or typographic) were considered as an email so we had several empty emails into the conversation. Now the contiguous patterns of transition are concatenate even if there are typography between them. So there are no more empty (only typographic) email into the conversation.

Furthermore, if an email begins by a transition then it is handled (it wasn't handled before because the sort of the index was done only on the first index of the tuples).

Modification of the unit_test to check that improvement.

In addition, debug of the printer. We have to remove the \r before to use the print_color.
