### PR TITLE
fix conflict version travis

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,7 @@ Sphinx==3.0.4
 sphinx-bootstrap-theme==0.6.5
 tox==3.5.2
 twine==1.12.1
+importlib-metadata>=1
 psutil>=5.7.0
 pytest==3.8.2
 pytest-runner==4.2


### PR DESCRIPTION
Trying to solve conflict version on travis 

"pkg_resources.ContextualVersionConflict: (importlib-metadata 0.18 (/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages), Requirement.parse('importlib-metadata>=1; python_version < "3.8"'), {'keyring'})"