### PR TITLE
FIX Issue #92

### DIFF
--- a/melusine/prepare_email/metadata_engineering.py
+++ b/melusine/prepare_email/metadata_engineering.py
@@ -133,12 +133,6 @@ class MetaDate(BaseEstimator, TransformerMixin):
 
         """Transform date to hour, min, day features."""
         X["date"] = apply_func(X, self.date_formatting, args_=(self.regex_date_format,))
-        X["date"] = pd.to_datetime(
-            X["date"],
-            format=self.date_format,
-            infer_datetime_format=False,
-            errors="coerce",
-        )
         X["hour"] = apply_func(X, self.get_hour)
         X["min"] = apply_func(X, self.get_min)
         X["dayofweek"] = apply_func(X, self.get_dayofweek)
@@ -152,8 +146,13 @@ class MetaDate(BaseEstimator, TransformerMixin):
             date = e[0] + "/" + e[1] + "/" + e[2] + " " + e[3] + ":" + e[4]
             for m, m_n in self.month.items():
                 date = date.replace(m, m_n)
+            date = pd.to_datetime(date,
+                format=self.date_format,
+                infer_datetime_format=False,
+                errors="coerce",
+            )
         except Exception:
-            return x
+            return pd.to_datetime(x)
         return date
 
     @staticmethod


### PR DESCRIPTION
# Description

We keep the "try-except" mechanism to have the same configuration but we include the to_datetime with the specific format in the try and in the except we do not set the format of datetime and let its chance to the date which not fit the format. 

Fixes #92 

The date regex format is set in the code and not in config so it does not allow its user to customize.  

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

We modified the  melusine/data/emails.csv file with our date format and tried the modifications. 

**Test Configuration**:
* OS: Windows 10
* Python version: 3.7
* Melusine version: 2.3.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
