### PR TITLE
modification train.py pour sauvegarder Bert

### DIFF
--- a/melusine/models/train.py
+++ b/melusine/models/train.py
@@ -214,6 +214,7 @@ class NeuralModel(BaseEstimator, ClassifierMixin):
         dict_attr = dict(self.__dict__)
         if "model" in dict_attr:
             del dict_attr["model"]
+        if "embedding_matrix" in dict_attr:
             del dict_attr["embedding_matrix"]
             del dict_attr["pretrained_embedding"]
         return dict_attr


### PR DESCRIPTION
Hello every one,

I have modified the file train.py for enabling Bert model fonction save.
My modification is : 

```
def __getstate__(self):
        """Method called before serialization for a specific treatment to save
        model weight and structure instead of standard serialization."""
        dict_attr = dict(self.__dict__)
        if "model" in dict_attr:
            del dict_attr["model"]
        if "embedding_matrix" in dict_attr:
            del dict_attr["embedding_matrix"]
            del dict_attr["pretrained_embedding"]
        return dict_attr
```

I am happy to contribute to this reat projet.