### PR TITLE
Add Python 3.12 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.8", "3.10", "3.12"]
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v3

--- a/melusine/_config.py
+++ b/melusine/_config.py
@@ -99,14 +99,15 @@ class MelusineConfig(UserDict):
 
         Returns
         -------
-        _:
+        _: the list of all copied files.
         """
-        from distutils.dir_util import copy_tree
+        from shutil import copytree
 
         source = self.DEFAULT_CONFIG_PATH
-        file_list: List[str] = copy_tree(source, path)
+        new_directory: str = copytree(source, path, dirs_exist_ok=True)
+        copied_files = [str(path) for path in Path(new_directory).rglob("*") if path.is_file()]
 
-        return file_list
+        return copied_files
 
 
 # Load Melusine configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Natural Language :: English",
 ]
 dependencies = [


### PR DESCRIPTION
Update the codebase to add compatibility with Python 3.12. It does not break compatibility with older versions of Python.